### PR TITLE
Fix api data address

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://megasense-server.cs.helsinki.fi/fwowebserver",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "NODE_ENV=development vite build",
     "build-prod": "vite build --base=/fwowebserver/",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/src/frontend/src/services/requestservice.jsx
+++ b/src/frontend/src/services/requestservice.jsx
@@ -1,6 +1,14 @@
 import axios from 'axios'
 
-const dataApi = 'http://127.0.0.1:5000/api/data'
+
+let base_api_url= ``
+
+if(import.meta.env.DEV)
+    base_api_url = 'http://127.0.0.1:5000'
+else
+    base_api_url = 'https://megasense-server.cs.helsinki.fi/fwowebserver'
+
+const dataApi = `${base_api_url}/api/data`
 
 const getDataFromFlask = async () => {
     console.log('GET - request to flask')


### PR DESCRIPTION
I set the API data address to use env variable. Local build will yield the base api address to be localhost:5000 while build for production makes it to be https://megasense-server.cs.helsinki.fi/fwowebserver, so that react can access api/data on cloud server.